### PR TITLE
Implemented invalidate() in EndSubTextLabel

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui.common.graph/src/eu/esdihumboldt/hale/ui/common/graph/figures/EndSubTextLabel.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.common.graph/src/eu/esdihumboldt/hale/ui/common/graph/figures/EndSubTextLabel.java
@@ -54,4 +54,14 @@ public class EndSubTextLabel extends Label {
 		return subStringText;
 	}
 
+	/**
+	 * @see org.eclipse.draw2d.Label#invalidate()
+	 */
+	@Override
+	public void invalidate() {
+		subStringText = null;
+
+		super.invalidate();
+	}
+
 }


### PR DESCRIPTION
This should allow proper resizing of the EndSubTextLabels